### PR TITLE
Fix some bugs in the way DNS compression is handled in dns.c

### DIFF
--- a/examples/dns/dns.c
+++ b/examples/dns/dns.c
@@ -2,6 +2,8 @@
 int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *current){
         if(current->bit_offset) return -1;
         size_t begin_labels = current->pos;
+        // When following pointers, we should never cross this offset
+        size_t current_limit = begin_labels;
         size_t pos = begin_labels;
         int first_label = 1;
         //First, figure out how large the stream should be.
@@ -25,6 +27,10 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                                 current->pos = pos+1;
                         }
                         pos = (highbyte & 63) << 8 | current->data[pos];
+                        // Compression pointers should always point backwards
+                        if (pos >= current_limit)
+                          return -1;
+                        current_limit = pos;
                 } else {
                         size += highbyte;
                         pos += highbyte;

--- a/examples/dns/dns.c
+++ b/examples/dns/dns.c
@@ -24,7 +24,7 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                                 first_label = 0;
                                 current->pos = pos+1;
                         }
-                        pos = highbyte & 63 << 8 | current->data[pos];
+                        pos = (highbyte & 63) << 8 | current->data[pos];
                 } else {
                         size += highbyte;
                         pos += highbyte;
@@ -42,7 +42,7 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                 highbyte = current->data[pos];
                 if(highbyte >= 192){                     
                         if(pos >= current->size) return -1;
-                        pos = highbyte & 63 << 8 | current->data[pos+1];
+                        pos = (highbyte & 63) << 8 | current->data[pos+1];
                         continue;
                 }
                 memcpy((uint8_t *)str_decompressed->data + str_decompressed->pos, current->data + pos, highbyte + 1);

--- a/examples/dns_cpp/dns/dns.c
+++ b/examples/dns_cpp/dns/dns.c
@@ -24,7 +24,7 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                                 first_label = 0;
                                 current->pos = pos+1;
                         }
-                        pos = highbyte & 63 << 8 | current->data[pos];
+                        pos = (highbyte & 63) << 8 | current->data[pos];
                 } else {
                         size += highbyte;
                         pos += highbyte;
@@ -42,7 +42,7 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                 highbyte = current->data[pos];
                 if(highbyte >= 192){                     
                         if(pos >= current->size) return -1;
-                        pos = highbyte & 63 << 8 | current->data[pos+1];
+                        pos = (highbyte & 63) << 8 | current->data[pos+1];
                         continue;
                 }
                 memcpy(str_decompressed->data + str_decompressed->pos, current->data + pos, highbyte + 1);

--- a/examples/dns_cpp/dns/dns.c
+++ b/examples/dns_cpp/dns/dns.c
@@ -2,6 +2,8 @@
 int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *current){
         if(current->bit_offset) return -1;
         size_t begin_labels = current->pos;
+        // When following pointers, we should never cross this offset
+        size_t current_limit = begin_labels;
         size_t pos = begin_labels;
         int first_label = 1;
         //First, figure out how large the stream should be.
@@ -25,6 +27,10 @@ int dnscompress_parse(NailArena *tmp,NailStream *str_decompressed, NailStream *c
                                 current->pos = pos+1;
                         }
                         pos = (highbyte & 63) << 8 | current->data[pos];
+                        // Compression pointers should always point backwards
+                        if (pos >= current_limit)
+                          return -1;
+                        current_limit = pos;
                 } else {
                         size += highbyte;
                         pos += highbyte;


### PR DESCRIPTION
As described in issue #7 DNS decompression does not always work as expected.

This can lead to hangs (that we found with AFL). Some of them were due to a problem with operator precedence, but other were due to the fact the code carelessly follows compression pointers.

With the attached patches, we did not find hangs with AFL anymore.

Yet, the code is still not fully compliant, since it is possible to follow a pointer that does not correspond to a previously encountered label.